### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Mineways, a Minecraft mapper and exporter.
+# Mineways, a Minecraft mapper and exporter.
 **by Eric Haines, erich@acm.org**
 
 **begun 11/14/2011**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
