### PR TITLE
Fix hanging lantern chains

### DIFF
--- a/Win/nbt.cpp
+++ b/Win/nbt.cpp
@@ -3828,7 +3828,6 @@ static int readPalette(int& returnCode, bfFile* pbf, int mcVersion, unsigned cha
         case STANDING_SIGN_PROP:
         case WT_PRESSURE_PROP:
         case PICKLE_PROP:
-        case LANTERN_PROP:
         case WIRE_PROP:
         case STRUCTURE_PROP:
             break;
@@ -4258,6 +4257,9 @@ static int readPalette(int& returnCode, bfFile* pbf, int mcVersion, unsigned cha
             if (berries) {
                 paletteBlockEntry[entryIndex]++;
             }
+            break;
+        case LANTERN_PROP:
+            dataVal = hanging ? 1 : 0;
             break;
         case PROPAGULE_PROP:
             // use the age only if hanging. Age otherwise appears irrelevant?


### PR DESCRIPTION
7a7ab9b496775d024ac3368a8f9495157255df7b added support for Minecraft 1.19 worlds, and made a slight adjustment to allow lanterns and propagules to share behavior for the `"hanging"` tag, but did not add a case for lanterns to keep their `dataVal`. This caused hanging lanterns to export without their hanging chain.

This fix simply adds a switch case for lanterns to restore the proper `dataVal`.