### PR TITLE
Adjust wall torch angle and base height

### DIFF
--- a/Win/ObjFileManip.cpp
+++ b/Win/ObjFileManip.cpp
@@ -14616,13 +14616,13 @@ static int saveBillboardFacesExtraData(int boxIndex, int type, int billboardType
             // this moves block up so that bottom of torch is at Y=0
             // also move to wall
             translateMtx(mtx, 0.0f, 0.5f, 0.0f);
-            rotateMtx(mtx, 20.0f, 0.0f, 0.0f);
+            rotateMtx(mtx, 22.5f, 0.0f, 0.0f);
             // in 1.7 and earlier torches are sheared:
             // shearMtx(mtx, 0.0f, shr);
             translateMtx(mtx, 0.0f, 0.0f, trans);
             rotateMtx(mtx, 0.0f, yAngle, 0.0f);
             // undo translation, and kick it up the wall a bit
-            translateMtx(mtx, 0.0f, -0.5f + 3.8f / 16.0f, 0.0f);
+            translateMtx(mtx, 0.0f, -0.5f + 3.5f / 16.0f, 0.0f);
             translateFromOriginMtx(mtx, boxIndex);
             transformVertices(totalVertexCount, mtx);
         }


### PR DESCRIPTION
This PR adjusts wall torch angle and base height to better match Minecraft as illustrated below. Torch angle is 22.5 degrees since that is [half of 45 degrees](https://minecraft.fandom.com/wiki/Tutorials/Models#Block_models).

Ground truth:
![Minecraft_1 21 1](https://github.com/user-attachments/assets/0d37d294-6e1b-4818-a6fd-17cb9e0d401a)

Before fix (torch brightness has been set to a low value for faster convergence):
![render_before](https://github.com/user-attachments/assets/253868b5-e39a-4e16-a6b2-eb438ff8c9cd)

After fix:
![render_after](https://github.com/user-attachments/assets/e6a9e855-863b-4138-b15c-dcee0c96d930)
