### PR TITLE
Create workflow for building on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build-for-windows:
+    name: Build for Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: microsoft/setup-msbuild@v1.0.2
+      - run: msbuild Mineways.sln /p:Configuration=Release /p:Platform="x64"
+
+      - name: Upload .EXE artifact for Windows
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-exe
+          path: D:\a\Mineways\Mineways\x64\Release\Mineways.exe


### PR DESCRIPTION
I originally created this pull request to add support for macOS automatically using Wineskin, but I didn't know at the time at Wineskin was a GUI app instead of a CLI program. I think this pull request is still useful though as it
 - Automates the building for Windows
 - Adds accessibility for those who wants to download from the GitHub repository
 - You don't need to manually check if new code works via a pull request
 - Opens the possibility for automating wineskining the program in the future